### PR TITLE
Fix telegram bot startup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -108,7 +108,7 @@ async def handle_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
     if os.path.exists(output_file):
         await update.message.reply_photo(photo=open(output_file, "rb"))
 
-async def main() -> None:
+def main() -> None:
     token = os.environ.get("TELEGRAM_TOKEN")
     if not token:
         raise RuntimeError("TELEGRAM_TOKEN environment variable is required")
@@ -118,11 +118,7 @@ async def main() -> None:
     application.add_handler(MessageHandler(filters.Document.ALL, handle_file))
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_text))
 
-    await application.initialize()
-    await application.start()
-    await application.updater.start_polling()
-    await application.updater.idle()
+    application.run_polling()
 
 if __name__ == "__main__":
-    import asyncio
-    asyncio.run(main())
+    main()


### PR DESCRIPTION
## Summary
- use the synchronous `run_polling()` helper instead of manual start/idle logic

## Testing
- `python -m py_compile bot.py`
- `python bot.py` *(fails: `OPENROUTER_API_KEY environment variable is required`)*

------
https://chatgpt.com/codex/tasks/task_e_686445a26208832a871723eae5c3dff7