### PR TITLE
Add model selection via env or CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a simple Telegram bot that lets users chat with their d
 
 1. Users upload a `.csv` or `.xlsx` file to the bot.
 2. They ask questions about the data in natural language.
-3. The bot sends the request along with a summary of the table to the OpenRouter API using the `openai/gpt-4.1-mini` model. The model returns Python code that answers the question.
+3. The bot sends the request along with a summary of the table to the OpenRouter API using a model of your choice (defaults to `openai/gpt-4.1-mini`). The model returns Python code that answers the question.
 4. The returned code is executed and the resulting text and/or plot is sent back to the user.
 
 ## Running
@@ -13,10 +13,13 @@ Set the following environment variables:
 
 - `TELEGRAM_TOKEN` – Telegram bot token.
 - `OPENROUTER_API_KEY` – API key for [openrouter.ai](https://openrouter.ai/).
+- `OPENROUTER_MODEL` – Optional model name. Defaults to `openai/gpt-4.1-mini`.
 
 Install dependencies and start the bot:
 
 ```bash
 pip install -r requirements.txt
-python bot.py
+python bot.py  # default model
+# or specify a model
+# python bot.py --model openai/gpt-3.5-turbo
 ```

--- a/bot.py
+++ b/bot.py
@@ -2,6 +2,7 @@ import os
 import io
 import logging
 from contextlib import redirect_stdout
+import argparse
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -26,7 +27,9 @@ openai_client = AsyncOpenAI(
     api_key=OPENROUTER_API_KEY,
     base_url="https://openrouter.ai/api/v1",
 )
-MODEL = "openai/gpt-4.1-mini"
+
+DEFAULT_MODEL = "openai/gpt-4.1-mini"
+MODEL = os.environ.get("OPENROUTER_MODEL", DEFAULT_MODEL)
 
 # In-memory user storage
 user_data = {}
@@ -111,6 +114,18 @@ async def handle_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         await update.message.reply_photo(photo=open(output_file, "rb"))
 
 def main() -> None:
+    global MODEL
+
+    parser = argparse.ArgumentParser(description="Chatable Telegram Bot")
+    parser.add_argument(
+        "--model",
+        default=MODEL,
+        help="OpenRouter model name",
+    )
+    args = parser.parse_args()
+
+    MODEL = args.model
+
     token = os.environ.get("TELEGRAM_TOKEN")
     if not token:
         raise RuntimeError("TELEGRAM_TOKEN environment variable is required")


### PR DESCRIPTION
## Summary
- make model configurable with `OPENROUTER_MODEL` env var
- allow overriding model using `--model` CLI argument
- document the new option in the README

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68644cb32a4c832ab28cb431eb97ac14