### PR TITLE
Log failed code

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -106,6 +106,7 @@ async def handle_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         with redirect_stdout(stdout):
             exec(code, {}, local_vars)
     except Exception as e:
+        logger.exception("Error executing code:\n%s", code)
         await update.message.reply_text(f"Error executing code: {e}")
         return
     output_text = stdout.getvalue()


### PR DESCRIPTION
## Summary
- log the failed Python code when executing generated snippets

## Testing
- `python -m py_compile bot.py`
- `pip install -r requirements.txt`
- `OPENROUTER_API_KEY=dummy python bot.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68644df9bebc832ab7f6095bcf452806