### PR TITLE
Improve Docker usage documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENTRYPOINT ["python", "bot.py"]
+CMD []

--- a/README.md
+++ b/README.md
@@ -23,3 +23,24 @@ python bot.py  # default model
 # or specify a model
 # python bot.py --model openai/gpt-3.5-turbo
 ```
+
+## Docker
+
+Build the image:
+
+```bash
+docker build -t chatable .
+```
+
+Run the bot with the required environment variables:
+
+```bash
+docker run -e TELEGRAM_TOKEN=your_token -e OPENROUTER_API_KEY=your_key chatable
+```
+
+To choose a different model, either set `OPENROUTER_MODEL` or pass a flag:
+
+```bash
+docker run -e TELEGRAM_TOKEN=your_token -e OPENROUTER_API_KEY=your_key \
+  chatable --model openai/gpt-3.5-turbo
+```


### PR DESCRIPTION
## Summary
- expose bot.py as entrypoint in Dockerfile so additional CLI flags can be used
- document how to build and run the container with environment variables or `--model`

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68644fd5977c832a91c6b7b5a7734a48